### PR TITLE
popm register list is backwards from pushm

### DIFF
--- a/mc/instr/__init__.py
+++ b/mc/instr/__init__.py
@@ -611,14 +611,37 @@ class OperBitBase11SB(OperBitIndAbs):
 
 
 class OperMultiReg(Operand):
+    def __init__(self, is_popm):
+        self.is_popm = is_popm
+
     def length(self):
         return 1
 
     def decode(self, opcode, decoder, addr):
-        self.reg_mask = decoder.unsigned_byte()
+        reg_mask = decoder.unsigned_byte()
+
+        if self.is_popm:
+            reversed_mask = 0
+            for i in range(0, 8):
+                if reg_mask & (1 << i) != 0:
+                    reversed_mask |= 1 << (7 - i)
+
+            reg_mask = reversed_mask
+
+        self.reg_mask = reg_mask
 
     def encode(self, opcode, encoder, addr):
-        encoder.unsigned_byte(self.reg_mask)
+        reg_mask = self.reg_mask
+
+        if self.is_popm:
+            reversed_mask = 0
+            for i in range(0, 8):
+                if reg_mask & (1 << i) != 0:
+                    reversed_mask |= 1 << (7 - i)
+
+            reg_mask = reversed_mask
+
+        encoder.unsigned_byte(reg_mask)
         return opcode
 
     def render(self, addr):

--- a/mc/instr/__init__.py
+++ b/mc/instr/__init__.py
@@ -625,7 +625,7 @@ class OperMultiReg(Operand):
         return opcode
 
     def render(self, addr):
-        register_list = ['FB', 'SB', 'A1', 'A0', 'R3', 'R2', 'R1', 'R0']
+        register_list = ['R0', 'R1', 'R2', 'R3', 'A0', 'A1', 'SB', 'FB']
         if self.reversed:
             register_list = reversed(register_list)
         tokens = []

--- a/mc/instr/__init__.py
+++ b/mc/instr/__init__.py
@@ -611,42 +611,25 @@ class OperBitBase11SB(OperBitIndAbs):
 
 
 class OperMultiReg(Operand):
-    def __init__(self, is_popm):
-        self.is_popm = is_popm
+    def __init__(self, reversed):
+        self.reversed = reversed
 
     def length(self):
         return 1
 
     def decode(self, opcode, decoder, addr):
-        reg_mask = decoder.unsigned_byte()
-
-        if self.is_popm:
-            reversed_mask = 0
-            for i in range(0, 8):
-                if reg_mask & (1 << i) != 0:
-                    reversed_mask |= 1 << (7 - i)
-
-            reg_mask = reversed_mask
-
-        self.reg_mask = reg_mask
+        self.reg_mask = decoder.unsigned_byte()
 
     def encode(self, opcode, encoder, addr):
-        reg_mask = self.reg_mask
-
-        if self.is_popm:
-            reversed_mask = 0
-            for i in range(0, 8):
-                if reg_mask & (1 << i) != 0:
-                    reversed_mask |= 1 << (7 - i)
-
-            reg_mask = reversed_mask
-
-        encoder.unsigned_byte(reg_mask)
+        encoder.unsigned_byte(self.reg_mask)
         return opcode
 
     def render(self, addr):
+        register_list = ['FB', 'SB', 'A1', 'A0', 'R3', 'R2', 'R1', 'R0']
+        if self.reversed:
+            register_list = reversed(register_list)
         tokens = []
-        for index, reg in enumerate(['FB', 'SB', 'A1', 'A0', 'R3', 'R2', 'R1', 'R0']):
+        for index, reg in enumerate(register_list):
             if self.reg_mask & (1 << index):
                 if tokens:
                     tokens += asm(('opsep', ', '))

--- a/mc/instr/stack.py
+++ b/mc/instr/stack.py
@@ -94,7 +94,7 @@ class Pushm(InstrShortOpcode):
         return 'PUSHM'
 
     def new_operands(self):
-        return [OperMultiReg(is_popm=False)]
+        return [OperMultiReg(reversed=False)]
 
 
 class PopReg8(InstrShortOpcode):
@@ -134,4 +134,4 @@ class Popm(InstrShortOpcode):
         return 'POPM'
 
     def new_operands(self):
-        return [OperMultiReg(is_popm=True)]
+        return [OperMultiReg(reversed=True)]

--- a/mc/instr/stack.py
+++ b/mc/instr/stack.py
@@ -94,7 +94,7 @@ class Pushm(InstrShortOpcode):
         return 'PUSHM'
 
     def new_operands(self):
-        return [OperMultiReg()]
+        return [OperMultiReg(is_popm=False)]
 
 
 class PopReg8(InstrShortOpcode):
@@ -134,4 +134,4 @@ class Popm(InstrShortOpcode):
         return 'POPM'
 
     def new_operands(self):
-        return [OperMultiReg()]
+        return [OperMultiReg(is_popm=True)]


### PR DESCRIPTION
... because of course it is. i noticed this in looking at a firmware through my implementation, consulted against yours as a reference, and didn't see any pushm/popm sensitive logic, so i think i've found and fixed a bug. i don't have a usable copy of binja on hand anymore, so this is best-effort from reading and hoping i haven't missed anything. the firmware i was looking at is from [USBcanII](https://www.kvaser.com/product/kvaser-usbcan-ii-hshs/), where pushm/popm are used on function entry/exit and mismatched register lists become pretty obvious.

if you do reverse the register list for one of pushm/popm somewhere and i missed it .. oops, sorry.

one such function, addresses, and disassembly, for reference: ![Selection_019](https://user-images.githubusercontent.com/4615790/73636156-15f9ae00-461a-11ea-8eae-692ccdc0fb08.png)

-------

from `M16C/60, M16C/20, M16C/Tiny Series Software Manual`, the encoding
of PUSHM (page 219) has registers specified in the order

```
-----------------------------------------------
| reg | R0 | R1 | R2 | R3 | A0 | A1 | SB | FB |
| bit |  7 |  6 |  5 |  4 |  3 |  2 |  1 |  0 |
-----------------------------------------------
```
whereas POPM (page 215) has the register list backwards:
```
-----------------------------------------------
| reg | FB | SB | A1 | A0 | R3 | R2 | R1 | R0 |
| bit |  7 |  6 |  5 |  4 |  3 |  2 |  1 |  0 |
-----------------------------------------------
```
this change canonicalizes the order to pushm order, swapping on encode
and decode to the correct order for whichever of pushm/popm are used.